### PR TITLE
adds dat-keyserver to application list

### DIFF
--- a/content/apps/index.txt
+++ b/content/apps/index.txt
@@ -48,6 +48,11 @@ list:
     title: Ara File Manager
     description: An ethereum app for publishing, selling, and purchasing digital content through the Ara network
     tags: electron, gui, ethereum, blockchain
+  dat-keyserver:
+    link: https://github.com/tdjsnelling/dat-keyserver
+    title: dat-keyserver
+    description: a distributed PGP keyserver project based on the dat protocol
+    tags: server, gui, pgp
 
 
 


### PR DESCRIPTION
Hey, would be great to have [dat-keyserver](https://github.com/tdjsnelling/dat-keyserver) on the applications list.