### PR TITLE
Add Chirper webapp to list

### DIFF
--- a/content/apps/index.txt
+++ b/content/apps/index.txt
@@ -48,6 +48,11 @@ list:
     title: Ara File Manager
     description: An ethereum app for publishing, selling, and purchasing digital content through the Ara network
     tags: electron, gui, ethereum, blockchain
+  chirper:
+    link: https://github.com/filipdanic/chirper
+    title: Chirper
+    description: An open source P2P Dat-powered app for sharing short form thoughts and notes called “chirps.” Built with React. Peer discovery works via webrtc-swarm and signalhub.
+    tags: browser, webapp
 
 
 


### PR DESCRIPTION
Hey, folks! 👋

Chirper is a web app I built in order to learn a bit about Dat and the surrounding ecosystem. The link is direct to the github repo that can hopefully serve as a good learning point/boilerplate for anyone who’s just getting started.

The app itself is basically a small Twitter clone. It’s being rehosted via Hashbase, so you should always be able to access it over dat://chirper.hashbase.io/