### PR TITLE
Redirect to new dat.foundation site (retire dat.land)

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -4,6 +4,9 @@ require('./design')
 var choo = require('choo')
 
 var app = choo()
+app.use(() => {
+  if (window.location.host === 'dat.land') return window.location = 'https://dat.foundation'
+})
 app.use(require('enoki/choo')())
 app.use(require('./plugins/scroll'))
 app.route('*', require('./views/wrapper'))


### PR DESCRIPTION
I've redirected the DNS but helpful to have a client redirect too for anyone going to https://dat.land directly.

With the launch of dat.foundation, we've moved most of the project and other learning stuff to consolidate there (see [this sitemap](https://dat.discourse.group/t/rebuilding-the-dat-website-proposed-site-map/79)). 

@okdistribute does this all make sense to you? 

Once this is done, we can archive this repo.